### PR TITLE
Add build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: rust
+
+jobs:
+  include:
+    - os: windows
+      rust: 
+      - nightly
+    - os: linux
+      rust: stable
+    - os: linux
+      rust: nightly
+
+cache: cargo
+
+script:
+- cargo build
+- cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ dependencies = [
  "crossbeam-channel",
  "lazy_static",
  "notify",
+ "rustc_version",
  "serde",
  "serde_json",
  "ureq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[build-dependencies]
+rustc_version = "0.2.3"
+
 [dependencies]
 crossbeam-channel = "0.4.2"
 lazy_static = "1.4.0"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Aloy
 
+[![Build Status](https://travis-ci.org/andyundso/aloy.svg?branch=master)](https://travis-ci.org/andyundso/aloy)
+
 Aloy hunts for machines (watching for files) and passes its loot (meta data) to a merchant (webservice).
 
 (Horizon: Zero Dawn is actually a good game).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Aloy hunts for machines (watching for files) and passes its loot (meta data) to 
 
 (Horizon: Zero Dawn is actually a good game).
 
+## Windows build
+
+The windows version of this package currently only builds against Nightly because the package relies on an unstable feature for gathering a file identifier.
+
 ## Configuration
 
 Aloy expects a configuration file in the project's root (TBC) as a JSON with an array of the paths you want to watch. An example file is present in the project.

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,9 @@
+// Stolen fro https://github.com/mockiato/mockiato/blob/master/build.rs
+
+use rustc_version::{version_meta, Channel};
+
+fn main() {
+    if let Channel::Nightly = version_meta().unwrap().channel {
+        println!("cargo:rustc-cfg=rustc_is_nightly");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(all(rustc_is_nightly, windows), feature(windows_by_handle))]
+
 mod watcher;
 
 #[macro_use]

--- a/src/watcher/file_identifier.rs
+++ b/src/watcher/file_identifier.rs
@@ -1,20 +1,46 @@
+use std::fs;
+use std::io;
+use std::path::PathBuf;
+
+#[cfg(target_os = "windows")]
+use std::os::windows::fs::MetadataExt;
+
+#[cfg(not(target_os = "windows"))]
+use std::os::unix::fs::MetadataExt;
+
 pub struct FileInformation {
   pub id: String,
   pub path: String,
   pub category: String,
 }
 
-#[cfg(windows)]
-pub fn file_information(path: PathBuf) -> io::Result<(u64)> {
-  Ok(1234)
+#[cfg(target_os = "windows")]
+pub fn file_information(path: PathBuf) -> io::Result<(FileInformation)> {
+    let meta = fs::metadata(path.clone())?;
+    let file_index = meta.file_index().unwrap_or(0);
+  
+    let file_information = FileInformation {
+      id: file_index.to_string().to_owned(),
+      path: path
+        .clone()
+        .into_os_string()
+        .into_string()
+        .unwrap()
+        .to_owned(),
+      category: if path.is_dir() {
+        "directory"
+      } else if path.is_file() {
+        "file"
+      } else {
+        "unknown"
+      }
+      .to_owned(),
+    };
+  
+    Ok(file_information)
 }
 
-#[cfg(not(windows))]
-use std::fs;
-use std::io;
-use std::os::unix::fs::MetadataExt;
-use std::path::PathBuf;
-
+#[cfg(not(target_os = "windows"))]
 pub fn file_information(path: PathBuf) -> io::Result<FileInformation> {
   let meta = fs::metadata(path.clone())?;
   let inode = meta.ino();


### PR DESCRIPTION
It's a bit more than the Travis build:

* Port the file identifier for Windows so the windows build has a chance to pass
* Compile aloy against nightly when on Windows so we can use the file_identifier feature.
* Add a nice badge to the README of the build passing.